### PR TITLE
Add a default config file without comments

### DIFF
--- a/cmd/goslmailer/goslmailer.conf
+++ b/cmd/goslmailer/goslmailer.conf
@@ -1,0 +1,72 @@
+{
+  "logfile": "/tmp/goslmailer.log",
+  "debugconfig": true,
+  "binpaths": {
+    "sacct":"/usr/bin/sacct",
+    "sstat":"/usr/bin/sstat"
+  },
+  "defaultconnector": "msteams",
+  "connectors": {
+    "msteams": {
+      "name": "dev channel",
+      "renderToFile": "yes",
+      "spoolDir": "/tmp",
+      "url": "https://msteams/webhook/url",
+      "adaptiveCardTemplate": "/path/template.json",
+      "useLookup": "GECOS"
+    },
+    "mailto": {
+      "name": "original slurm mail functionality,extended.",
+      "mailCmd": "/usr/bin/mutt",
+      "mailCmdParams": "-s \"Job {{ .SlurmEnvironment.SLURM_JOB_ID }} ({{ .SlurmEnvironment.SLURM_JOB_NAME }}) {{ .SlurmEnvironment.SLURM_JOB_MAIL_TYPE }}\"",
+      "mailTemplate": "/etc/slurm/mailTemplate.tmpl",
+      "mailFormat": "HTML",
+      "allowList": ".+@(imp|imba.oeaw|gmi.oeaw).ac.at",
+    },
+    "telegram": {
+      "name": "telegram bot",
+      "url": "",
+      "token": "PasteHereTelegramBotToken",
+      "renderToFile": "no",
+      "spoolDir": "/tmp/telegramgobs",
+      "messageTemplate": "/etc/slurm/telegramTemplate.md",
+      "useLookup": "no",
+      "format": "MarkdownV2"
+    },
+    "discord": {
+      "name": "DiscoSlurmBot",
+      "triggerString": "showmeslurm",
+      "token": "PasteBotTokenHere",
+      "messageTemplate": "/path/to/template.md"
+    },
+    "mattermost": {
+      "name": "MatTheSlurmBot",
+      "serverUrl": "https://someSpaceName.cloud.mattermost.com",
+      "wsUrl": "wss://someSpaceName.cloud.mattermost.com",
+      "token": "PasteBotTokenHere",
+      "triggerString": "showmeslurm",
+      "messageTemplate" : "/path/to/mattermostTemplate.md"
+    },
+    "matrix": {
+      "username": "@myuser:matrix.org",
+      "token": "syt_dGRpZG9ib3QXXXXXXXEyQMBEmvOVp_10Jm93",
+      "homeserver": "matrix.org",
+      "template": "/path/to/matrix_template.md"
+    },
+    "slack": {
+      "token": "PasteSlackBotTokenHere",
+      "messageTemplate": "/path/to/template.md",
+      "renderToFile": "spool",
+      "spoolDir": "/tmp"
+    }
+    "textfile": {
+      "path": "/tmp"
+    }
+  },
+  "qosmap": {
+    "RAPID": 3600,
+    "SHORT": 28800,
+    "MEDIUM": 172800,
+    "LONG": 1209600
+  },
+}


### PR DESCRIPTION
The JSON conf file will not run with the comments in it, so a copy should also be provided that doesn't require people to remove 60 lines of comments (any spaces after the actual json will cause the parser to crash), or to write out their own config file.